### PR TITLE
Add generated FHIR STU3 base models

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add datetime classes and parsers to serialize FHIR date primitives
 * Add link:https://fastlane.tools[Fastlane] and a fastlane action `fhir-kotlin` to generate Kotlin models using the `fhir-spec-parser`
 * Add FHIR generation config
-* Add generated FHIR Code Systems
+* Add generated FHIR code systems
+* Add generated FHIR base models
 
 === Changed
 

--- a/fastlane/actions/fhir_kotlin.rb
+++ b/fastlane/actions/fhir_kotlin.rb
@@ -118,9 +118,9 @@ module Fastlane
 
 
           # Move models
-          # movefiles(modelSource, "#{modelTarget}", base, file_type)
-          # movefiles(modelSource, "#{modelTarget}", complex, file_type)
-          # movefiles(modelSource, "#{modelTarget}", special, file_type)
+          movefiles(modelSource, "#{modelTarget}", base, file_type)
+          movefiles(modelSource, "#{modelTarget}", complex, file_type)
+          movefiles(modelSource, "#{modelTarget}", special, file_type)
           moveCodeSystems(codeSystemSource, "#{codeSystemTarget}")
           # movefiles(modelSource, "#{modelTarget}", model, file_type)
 

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Address.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Address.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.AddressType
+import care.data4life.fhir.stu3.codesystem.AddressUse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirAddress : FhirElement {
+
+    // The purpose of this address.
+    val use: AddressUse?
+
+    // Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.
+    val type: AddressType?
+
+    // Text representation of the address.
+    val text: String?
+
+    // Street name, number, direction & P.O. Box etc..
+    val line: List<String>?
+
+    // Name of city, town etc..
+    val city: String?
+
+    // District name (aka county).
+    val district: String?
+
+    // Sub-unit of country (abbreviations ok).
+    val state: String?
+
+    // Postal code for area.
+    val postalCode: String?
+
+    // Country (e.g. can be ISO 3166 2 or 3 letter code).
+    val country: String?
+
+    // Time period when address was/is in use.
+    val period: Period?
+}
+
+
+/**
+ * ClassName: Address
+ *
+ * SourceFileName: Address.kt
+ *
+ *
+ * An address expressed using postal conventions (as opposed to GPS or other location definition formats).  This data type may be used to convey addresses for use in delivering mail as well as for visiting locations which might not be valid for mail delivery.  There are a variety of postal address formats defined around the world.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Address">Address</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Address) on 2020-10-01
+ */
+@Serializable
+@SerialName("Address")
+data class Address(
+
+    // The purpose of this address.
+    @SerialName("use")
+    override val use: AddressUse? = null,
+    // Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.
+    @SerialName("type")
+    override val type: AddressType? = null,
+    // Text representation of the address.
+    @SerialName("text")
+    override val text: String? = null,
+    // Street name, number, direction & P.O. Box etc..
+    @SerialName("line")
+    override val line: List<String>? = null,
+    // Name of city, town etc..
+    @SerialName("city")
+    override val city: String? = null,
+    // District name (aka county).
+    @SerialName("district")
+    override val district: String? = null,
+    // Sub-unit of country (abbreviations ok).
+    @SerialName("state")
+    override val state: String? = null,
+    // Postal code for area.
+    @SerialName("postalCode")
+    override val postalCode: String? = null,
+    // Country (e.g. can be ISO 3166 2 or 3 letter code).
+    @SerialName("country")
+    override val country: String? = null,
+    // Time period when address was/is in use.
+    @SerialName("period")
+    override val period: Period? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirAddress {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Address"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Age.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Age.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirAge : FhirQuantity
+
+
+/**
+ * ClassName: Age
+ *
+ * SourceFileName: Age.kt
+ *
+ *
+ * A duration of time during which an organism (or a process) has existed
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Age">Age</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Age) on 2020-10-01
+ */
+@Serializable
+@SerialName("Age")
+data class Age(
+
+
+    // # Quantity
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirAge {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Age"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Annotation.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Annotation.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirAnnotation : FhirElement {
+
+    // Individual responsible for the annotation.
+    val authorReference: Reference?
+
+    // Individual responsible for the annotation.
+    val authorString: String?
+
+    // When the annotation was made.
+    val time: String?
+
+    // The annotation  - text content.
+    val text: String
+}
+
+
+/**
+ * ClassName: Annotation
+ *
+ * SourceFileName: Annotation.kt
+ *
+ *
+ * A  text note which also  contains information about who made the statement and when.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Annotation">Annotation</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Annotation) on 2020-10-01
+ */
+@Serializable
+@SerialName("Annotation")
+data class Annotation(
+
+    // Individual responsible for the annotation.
+    @SerialName("authorReference")
+    override val authorReference: Reference? = null,
+    // Individual responsible for the annotation.
+    @SerialName("authorString")
+    override val authorString: String? = null,
+    // When the annotation was made.
+    @SerialName("time")
+    override val time: String? = null,
+    // The annotation  - text content.
+    @SerialName("text")
+    override val text: String,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirAnnotation {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Annotation"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Attachment.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Attachment.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirAttachment : FhirElement {
+
+    // Mime type of the content, with charset etc..
+    val contentType: String?
+
+    // Human language of the content (BCP-47).
+    val language: String?
+
+    // Data inline, base64ed.
+    val data: String?
+
+    // Uri where the data can be found.
+    val url: String?
+
+    // Number of bytes of content (if url provided).
+    val size: String?
+
+    // Hash of the data (sha-1, base64ed).
+    val hash: String?
+
+    // Label to display in place of the data.
+    val title: String?
+
+    // Date attachment was first created.
+    val creation: String?
+}
+
+
+/**
+ * ClassName: Attachment
+ *
+ * SourceFileName: Attachment.kt
+ *
+ *
+ * For referring to data content defined in other formats.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Attachment">Attachment</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Attachment) on 2020-10-01
+ */
+@Serializable
+@SerialName("Attachment")
+data class Attachment(
+
+    // Mime type of the content, with charset etc..
+    @SerialName("contentType")
+    override val contentType: String? = null,
+    // Human language of the content (BCP-47).
+    @SerialName("language")
+    override val language: String? = null,
+    // Data inline, base64ed.
+    @SerialName("data")
+    override val data: String? = null,
+    // Uri where the data can be found.
+    @SerialName("url")
+    override val url: String? = null,
+    // Number of bytes of content (if url provided).
+    @SerialName("size")
+    override val size: String? = null,
+    // Hash of the data (sha-1, base64ed).
+    @SerialName("hash")
+    override val hash: String? = null,
+    // Label to display in place of the data.
+    @SerialName("title")
+    override val title: String? = null,
+    // Date attachment was first created.
+    @SerialName("creation")
+    override val creation: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirAttachment {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Attachment"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/CodeableConcept.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/CodeableConcept.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirCodeableConcept : FhirElement {
+
+    // Code defined by a terminology system.
+    val coding: List<Coding>?
+
+    // Plain text representation of the concept.
+    val text: String?
+}
+
+
+/**
+ * ClassName: CodeableConcept
+ *
+ * SourceFileName: CodeableConcept.kt
+ *
+ *
+ * A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/CodeableConcept">CodeableConcept</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/CodeableConcept) on 2020-10-01
+ */
+@Serializable
+@SerialName("CodeableConcept")
+data class CodeableConcept(
+
+    // Code defined by a terminology system.
+    @SerialName("coding")
+    override val coding: List<Coding>? = null,
+    // Plain text representation of the concept.
+    @SerialName("text")
+    override val text: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirCodeableConcept {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "CodeableConcept"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Coding.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Coding.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirCoding : FhirElement {
+
+    // Identity of the terminology system.
+    val system: String?
+
+    // Version of the system - if relevant.
+    val version: String?
+
+    // Symbol in syntax defined by the system.
+    val code: String?
+
+    // Representation defined by the system.
+    val display: String?
+
+    // If this coding was chosen directly by the user.
+    val userSelected: String?
+}
+
+
+/**
+ * ClassName: Coding
+ *
+ * SourceFileName: Coding.kt
+ *
+ *
+ * A reference to a code defined by a terminology system
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Coding">Coding</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Coding) on 2020-10-01
+ */
+@Serializable
+@SerialName("Coding")
+data class Coding(
+
+    // Identity of the terminology system.
+    @SerialName("system")
+    override val system: String? = null,
+    // Version of the system - if relevant.
+    @SerialName("version")
+    override val version: String? = null,
+    // Symbol in syntax defined by the system.
+    @SerialName("code")
+    override val code: String? = null,
+    // Representation defined by the system.
+    @SerialName("display")
+    override val display: String? = null,
+    // If this coding was chosen directly by the user.
+    @SerialName("userSelected")
+    override val userSelected: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirCoding {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Coding"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/ContactPoint.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/ContactPoint.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.ContactPointSystem
+import care.data4life.fhir.stu3.codesystem.ContactPointUse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirContactPoint : FhirElement {
+
+    // Telecommunications form for contact point - what communications system is required to make use of the contact.
+    val system: ContactPointSystem?
+
+    // The actual contact point details.
+    val value: String?
+
+    // Identifies the purpose for the contact point.
+    val use: ContactPointUse?
+
+    // Specify preferred order of use (1 = highest).
+    val rank: String?
+
+    // Time period when the contact point was/is in use.
+    val period: Period?
+}
+
+
+/**
+ * ClassName: ContactPoint
+ *
+ * SourceFileName: ContactPoint.kt
+ *
+ *
+ * Details for all kinds of technology mediated contact points for a person or organization, including telephone, email, etc.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/ContactPoint">ContactPoint</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/ContactPoint) on 2020-10-01
+ */
+@Serializable
+@SerialName("ContactPoint")
+data class ContactPoint(
+
+    // Telecommunications form for contact point - what communications system is required to make use of the contact.
+    @SerialName("system")
+    override val system: ContactPointSystem? = null,
+    // The actual contact point details.
+    @SerialName("value")
+    override val value: String? = null,
+    // Identifies the purpose for the contact point.
+    @SerialName("use")
+    override val use: ContactPointUse? = null,
+    // Specify preferred order of use (1 = highest).
+    @SerialName("rank")
+    override val rank: String? = null,
+    // Time period when the contact point was/is in use.
+    @SerialName("period")
+    override val period: Period? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirContactPoint {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "ContactPoint"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Count.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Count.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirCount : FhirQuantity
+
+
+/**
+ * ClassName: Count
+ *
+ * SourceFileName: Count.kt
+ *
+ *
+ * A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Count">Count</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Count) on 2020-10-01
+ */
+@Serializable
+@SerialName("Count")
+data class Count(
+
+
+    // # Quantity
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirCount {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Count"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Distance.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Distance.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirDistance : FhirQuantity
+
+
+/**
+ * ClassName: Distance
+ *
+ * SourceFileName: Distance.kt
+ *
+ *
+ * A length - a value with a unit that is a physical distance
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Distance">Distance</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Distance) on 2020-10-01
+ */
+@Serializable
+@SerialName("Distance")
+data class Distance(
+
+
+    // # Quantity
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirDistance {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Distance"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Dosage.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Dosage.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirDosage : FhirElement {
+
+    // The order of the dosage instructions.
+    val sequence: String?
+
+    // Free text dosage instructions e.g. SIG.
+    val text: String?
+
+    // Supplemental instruction - e.g. "with meals".
+    val additionalInstruction: List<CodeableConcept>?
+
+    // Patient or consumer oriented instructions.
+    val patientInstruction: String?
+
+    // When medication should be administered.
+    val timing: Timing?
+
+    // Take "as needed" (for x).
+    val asNeededBoolean: String?
+
+    // Take "as needed" (for x).
+    val asNeededCodeableConcept: CodeableConcept?
+
+    // Body site to administer to.
+    val site: CodeableConcept?
+
+    // How drug should enter body.
+    val route: CodeableConcept?
+
+    // Technique for administering medication.
+    val method: CodeableConcept?
+
+    // Amount of medication per dose.
+    val doseRange: Range?
+
+    // Amount of medication per dose.
+    val doseQuantity: Quantity?
+
+    // Upper limit on medication per unit of time.
+    val maxDosePerPeriod: Ratio?
+
+    // Upper limit on medication per administration.
+    val maxDosePerAdministration: Quantity?
+
+    // Upper limit on medication per lifetime of the patient.
+    val maxDosePerLifetime: Quantity?
+
+    // Amount of medication per unit of time.
+    val rateRatio: Ratio?
+
+    // Amount of medication per unit of time.
+    val rateRange: Range?
+
+    // Amount of medication per unit of time.
+    val rateQuantity: Quantity?
+}
+
+
+/**
+ * ClassName: Dosage
+ *
+ * SourceFileName: Dosage.kt
+ *
+ *
+ * Indicates how the medication is/was taken or should be taken by the patient.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Dosage">Dosage</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Dosage) on 2020-10-01
+ */
+@Serializable
+@SerialName("Dosage")
+data class Dosage(
+
+    // The order of the dosage instructions.
+    @SerialName("sequence")
+    override val sequence: String? = null,
+    // Free text dosage instructions e.g. SIG.
+    @SerialName("text")
+    override val text: String? = null,
+    // Supplemental instruction - e.g. "with meals".
+    @SerialName("additionalInstruction")
+    override val additionalInstruction: List<CodeableConcept>? = null,
+    // Patient or consumer oriented instructions.
+    @SerialName("patientInstruction")
+    override val patientInstruction: String? = null,
+    // When medication should be administered.
+    @SerialName("timing")
+    override val timing: Timing? = null,
+    // Take "as needed" (for x).
+    @SerialName("asNeededBoolean")
+    override val asNeededBoolean: String? = null,
+    // Take "as needed" (for x).
+    @SerialName("asNeededCodeableConcept")
+    override val asNeededCodeableConcept: CodeableConcept? = null,
+    // Body site to administer to.
+    @SerialName("site")
+    override val site: CodeableConcept? = null,
+    // How drug should enter body.
+    @SerialName("route")
+    override val route: CodeableConcept? = null,
+    // Technique for administering medication.
+    @SerialName("method")
+    override val method: CodeableConcept? = null,
+    // Amount of medication per dose.
+    @SerialName("doseRange")
+    override val doseRange: Range? = null,
+    // Amount of medication per dose.
+    @SerialName("doseQuantity")
+    override val doseQuantity: Quantity? = null,
+    // Upper limit on medication per unit of time.
+    @SerialName("maxDosePerPeriod")
+    override val maxDosePerPeriod: Ratio? = null,
+    // Upper limit on medication per administration.
+    @SerialName("maxDosePerAdministration")
+    override val maxDosePerAdministration: Quantity? = null,
+    // Upper limit on medication per lifetime of the patient.
+    @SerialName("maxDosePerLifetime")
+    override val maxDosePerLifetime: Quantity? = null,
+    // Amount of medication per unit of time.
+    @SerialName("rateRatio")
+    override val rateRatio: Ratio? = null,
+    // Amount of medication per unit of time.
+    @SerialName("rateRange")
+    override val rateRange: Range? = null,
+    // Amount of medication per unit of time.
+    @SerialName("rateQuantity")
+    override val rateQuantity: Quantity? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirDosage {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Dosage"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Duration.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Duration.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirDuration : FhirQuantity
+
+
+/**
+ * ClassName: Duration
+ *
+ * SourceFileName: Duration.kt
+ *
+ *
+ * A length of time
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Duration">Duration</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Duration) on 2020-10-01
+ */
+@Serializable
+@SerialName("Duration")
+data class Duration(
+
+
+    // # Quantity
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirDuration {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Duration"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Element.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Element.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirElement : FhirStu3 {
+
+    // xml:id (or equivalent in JSON).
+    val id: String?
+
+    // Additional Content defined by implementations.
+    val extension: List<Extension>?
+}
+
+
+/**
+ * ClassName: Element
+ *
+ * SourceFileName: Element.kt
+ *
+ *
+ * Base definition for all elements in a resource.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Element">Element</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Element) on 2020-10-01
+ */
+@Serializable
+@SerialName("Element")
+data class Element(
+
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirElement {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Element"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Extension.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Extension.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirExtension : FhirElement {
+
+    // identifies the meaning of the extension.
+    val url: String
+
+    // Value of extension.
+    val valueBase64Binary: String?
+
+    // Value of extension.
+    val valueBoolean: String?
+
+    // Value of extension.
+    val valueCode: String?
+
+    // Value of extension.
+    val valueDate: String?
+
+    // Value of extension.
+    val valueDateTime: String?
+
+    // Value of extension.
+    val valueDecimal: String?
+
+    // Value of extension.
+    val valueId: String?
+
+    // Value of extension.
+    val valueInstant: String?
+
+    // Value of extension.
+    val valueInteger: String?
+
+    // Value of extension.
+    val valueMarkdown: String?
+
+    // Value of extension.
+    val valueOid: String?
+
+    // Value of extension.
+    val valuePositiveInt: String?
+
+    // Value of extension.
+    val valueString: String?
+
+    // Value of extension.
+    val valueTime: String?
+
+    // Value of extension.
+    val valueUnsignedInt: String?
+
+    // Value of extension.
+    val valueUri: String?
+
+    // Value of extension.
+    val valueAddress: Address?
+
+    // Value of extension.
+    val valueAge: Age?
+
+    // Value of extension.
+    val valueAnnotation: Annotation?
+
+    // Value of extension.
+    val valueAttachment: Attachment?
+
+    // Value of extension.
+    val valueCodeableConcept: CodeableConcept?
+
+    // Value of extension.
+    val valueCoding: Coding?
+
+    // Value of extension.
+    val valueContactPoint: ContactPoint?
+
+    // Value of extension.
+    val valueCount: Count?
+
+    // Value of extension.
+    val valueDistance: Distance?
+
+    // Value of extension.
+    val valueDuration: Duration?
+
+    // Value of extension.
+    val valueHumanName: HumanName?
+
+    // Value of extension.
+    val valueIdentifier: Identifier?
+
+    // Value of extension.
+    val valueMoney: Money?
+
+    // Value of extension.
+    val valuePeriod: Period?
+
+    // Value of extension.
+    val valueQuantity: Quantity?
+
+    // Value of extension.
+    val valueRange: Range?
+
+    // Value of extension.
+    val valueRatio: Ratio?
+
+    // Value of extension.
+    val valueReference: Reference?
+
+    // Value of extension.
+    val valueSampledData: SampledData?
+
+    // Value of extension.
+    val valueSignature: Signature?
+
+    // Value of extension.
+    val valueTiming: Timing?
+
+    // Value of extension.
+    val valueMeta: Meta?
+}
+
+
+/**
+ * ClassName: Extension
+ *
+ * SourceFileName: Extension.kt
+ *
+ *
+ * Optional Extension Element - found in all resources.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Extension">Extension</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Extension) on 2020-10-01
+ */
+@Serializable
+@SerialName("Extension")
+data class Extension(
+
+    // identifies the meaning of the extension.
+    @SerialName("url")
+    override val url: String,
+    // Value of extension.
+    @SerialName("valueBase64Binary")
+    override val valueBase64Binary: String? = null,
+    // Value of extension.
+    @SerialName("valueBoolean")
+    override val valueBoolean: String? = null,
+    // Value of extension.
+    @SerialName("valueCode")
+    override val valueCode: String? = null,
+    // Value of extension.
+    @SerialName("valueDate")
+    override val valueDate: String? = null,
+    // Value of extension.
+    @SerialName("valueDateTime")
+    override val valueDateTime: String? = null,
+    // Value of extension.
+    @SerialName("valueDecimal")
+    override val valueDecimal: String? = null,
+    // Value of extension.
+    @SerialName("valueId")
+    override val valueId: String? = null,
+    // Value of extension.
+    @SerialName("valueInstant")
+    override val valueInstant: String? = null,
+    // Value of extension.
+    @SerialName("valueInteger")
+    override val valueInteger: String? = null,
+    // Value of extension.
+    @SerialName("valueMarkdown")
+    override val valueMarkdown: String? = null,
+    // Value of extension.
+    @SerialName("valueOid")
+    override val valueOid: String? = null,
+    // Value of extension.
+    @SerialName("valuePositiveInt")
+    override val valuePositiveInt: String? = null,
+    // Value of extension.
+    @SerialName("valueString")
+    override val valueString: String? = null,
+    // Value of extension.
+    @SerialName("valueTime")
+    override val valueTime: String? = null,
+    // Value of extension.
+    @SerialName("valueUnsignedInt")
+    override val valueUnsignedInt: String? = null,
+    // Value of extension.
+    @SerialName("valueUri")
+    override val valueUri: String? = null,
+    // Value of extension.
+    @SerialName("valueAddress")
+    override val valueAddress: Address? = null,
+    // Value of extension.
+    @SerialName("valueAge")
+    override val valueAge: Age? = null,
+    // Value of extension.
+    @SerialName("valueAnnotation")
+    override val valueAnnotation: Annotation? = null,
+    // Value of extension.
+    @SerialName("valueAttachment")
+    override val valueAttachment: Attachment? = null,
+    // Value of extension.
+    @SerialName("valueCodeableConcept")
+    override val valueCodeableConcept: CodeableConcept? = null,
+    // Value of extension.
+    @SerialName("valueCoding")
+    override val valueCoding: Coding? = null,
+    // Value of extension.
+    @SerialName("valueContactPoint")
+    override val valueContactPoint: ContactPoint? = null,
+    // Value of extension.
+    @SerialName("valueCount")
+    override val valueCount: Count? = null,
+    // Value of extension.
+    @SerialName("valueDistance")
+    override val valueDistance: Distance? = null,
+    // Value of extension.
+    @SerialName("valueDuration")
+    override val valueDuration: Duration? = null,
+    // Value of extension.
+    @SerialName("valueHumanName")
+    override val valueHumanName: HumanName? = null,
+    // Value of extension.
+    @SerialName("valueIdentifier")
+    override val valueIdentifier: Identifier? = null,
+    // Value of extension.
+    @SerialName("valueMoney")
+    override val valueMoney: Money? = null,
+    // Value of extension.
+    @SerialName("valuePeriod")
+    override val valuePeriod: Period? = null,
+    // Value of extension.
+    @SerialName("valueQuantity")
+    override val valueQuantity: Quantity? = null,
+    // Value of extension.
+    @SerialName("valueRange")
+    override val valueRange: Range? = null,
+    // Value of extension.
+    @SerialName("valueRatio")
+    override val valueRatio: Ratio? = null,
+    // Value of extension.
+    @SerialName("valueReference")
+    override val valueReference: Reference? = null,
+    // Value of extension.
+    @SerialName("valueSampledData")
+    override val valueSampledData: SampledData? = null,
+    // Value of extension.
+    @SerialName("valueSignature")
+    override val valueSignature: Signature? = null,
+    // Value of extension.
+    @SerialName("valueTiming")
+    override val valueTiming: Timing? = null,
+    // Value of extension.
+    @SerialName("valueMeta")
+    override val valueMeta: Meta? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirExtension {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Extension"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/FhirSerializationModule.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/FhirSerializationModule.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+
+object FhirSerializationModule {
+
+    fun module(): SerializersModule {
+        return SerializersModule {
+            polymorphic(FhirStu3::class) {
+                subclass(Address::class)
+                subclass(Age::class)
+                subclass(Annotation::class)
+                subclass(Attachment::class)
+                subclass(CodeableConcept::class)
+                subclass(Coding::class)
+                subclass(ContactPoint::class)
+                subclass(Count::class)
+                subclass(Distance::class)
+                subclass(Dosage::class)
+                subclass(Duration::class)
+                subclass(Element::class)
+                subclass(Extension::class)
+                subclass(HumanName::class)
+                subclass(Identifier::class)
+                subclass(Meta::class)
+                subclass(Money::class)
+                subclass(Narrative::class)
+                subclass(Period::class)
+                subclass(Quantity::class)
+                subclass(Range::class)
+                subclass(Ratio::class)
+                subclass(Reference::class)
+                subclass(Resource::class)
+                subclass(SampledData::class)
+                subclass(Signature::class)
+                subclass(Timing::class)
+            }
+        }
+    }
+}

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/HumanName.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/HumanName.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.NameUse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirHumanName : FhirElement {
+
+    // Identifies the purpose for this name.
+    val use: NameUse?
+
+    // Text representation of the full name.
+    val text: String?
+
+    // Family name (often called 'Surname').
+    val family: String?
+
+    // Given names (not always 'first'). Includes middle names.
+    val given: List<String>?
+
+    // Parts that come before the name.
+    val prefix: List<String>?
+
+    // Parts that come after the name.
+    val suffix: List<String>?
+
+    // Time period when name was/is in use.
+    val period: Period?
+}
+
+
+/**
+ * ClassName: HumanName
+ *
+ * SourceFileName: HumanName.kt
+ *
+ *
+ * A human's name with the ability to identify parts and usage.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/HumanName">HumanName</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/HumanName) on 2020-10-01
+ */
+@Serializable
+@SerialName("HumanName")
+data class HumanName(
+
+    // Identifies the purpose for this name.
+    @SerialName("use")
+    override val use: NameUse? = null,
+    // Text representation of the full name.
+    @SerialName("text")
+    override val text: String? = null,
+    // Family name (often called 'Surname').
+    @SerialName("family")
+    override val family: String? = null,
+    // Given names (not always 'first'). Includes middle names.
+    @SerialName("given")
+    override val given: List<String>? = null,
+    // Parts that come before the name.
+    @SerialName("prefix")
+    override val prefix: List<String>? = null,
+    // Parts that come after the name.
+    @SerialName("suffix")
+    override val suffix: List<String>? = null,
+    // Time period when name was/is in use.
+    @SerialName("period")
+    override val period: Period? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirHumanName {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "HumanName"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Identifier.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Identifier.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.IdentifierUse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirIdentifier : FhirElement {
+
+    // The purpose of this identifier.
+    val use: IdentifierUse?
+
+    // Description of identifier.
+    val type: CodeableConcept?
+
+    // The namespace for the identifier value.
+    val system: String?
+
+    // The value that is unique.
+    val value: String?
+
+    // Time period when id is/was valid for use.
+    val period: Period?
+
+    // Organization that issued id (may be just text).
+    val assigner: Reference?
+}
+
+
+/**
+ * ClassName: Identifier
+ *
+ * SourceFileName: Identifier.kt
+ *
+ *
+ * A technical identifier - identifies some entity uniquely and unambiguously.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Identifier">Identifier</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Identifier) on 2020-10-01
+ */
+@Serializable
+@SerialName("Identifier")
+data class Identifier(
+
+    // The purpose of this identifier.
+    @SerialName("use")
+    override val use: IdentifierUse? = null,
+    // Description of identifier.
+    @SerialName("type")
+    override val type: CodeableConcept? = null,
+    // The namespace for the identifier value.
+    @SerialName("system")
+    override val system: String? = null,
+    // The value that is unique.
+    @SerialName("value")
+    override val value: String? = null,
+    // Time period when id is/was valid for use.
+    @SerialName("period")
+    override val period: Period? = null,
+    // Organization that issued id (may be just text).
+    @SerialName("assigner")
+    override val assigner: Reference? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirIdentifier {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Identifier"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Meta.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Meta.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirMeta : FhirElement {
+
+    // Version specific identifier.
+    val versionId: String?
+
+    // When the resource version last changed.
+    val lastUpdated: String?
+
+    // Profiles this resource claims to conform to.
+    val profile: List<String>?
+
+    // Security Labels applied to this resource.
+    val security: List<Coding>?
+
+    // Tags applied to this resource.
+    val tag: List<Coding>?
+}
+
+
+/**
+ * ClassName: Meta
+ *
+ * SourceFileName: Meta.kt
+ *
+ *
+ * The metadata about a resource. This is content in the resource that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Meta">Meta</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Meta) on 2020-10-01
+ */
+@Serializable
+@SerialName("Meta")
+data class Meta(
+
+    // Version specific identifier.
+    @SerialName("versionId")
+    override val versionId: String? = null,
+    // When the resource version last changed.
+    @SerialName("lastUpdated")
+    override val lastUpdated: String? = null,
+    // Profiles this resource claims to conform to.
+    @SerialName("profile")
+    override val profile: List<String>? = null,
+    // Security Labels applied to this resource.
+    @SerialName("security")
+    override val security: List<Coding>? = null,
+    // Tags applied to this resource.
+    @SerialName("tag")
+    override val tag: List<Coding>? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirMeta {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Meta"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Money.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Money.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirMoney : FhirQuantity
+
+
+/**
+ * ClassName: Money
+ *
+ * SourceFileName: Money.kt
+ *
+ *
+ * An amount of economic utility in some recognized currency
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Money">Money</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Money) on 2020-10-01
+ */
+@Serializable
+@SerialName("Money")
+data class Money(
+
+
+    // # Quantity
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirMoney {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Money"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Narrative.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Narrative.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.NarrativeStatus
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirNarrative : FhirElement {
+
+    // The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
+    val status: NarrativeStatus
+
+    // Limited xhtml content.
+    val div: String
+}
+
+
+/**
+ * ClassName: Narrative
+ *
+ * SourceFileName: Narrative.kt
+ *
+ *
+ * A human-readable formatted text, including images
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Narrative">Narrative</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Narrative) on 2020-10-01
+ */
+@Serializable
+@SerialName("Narrative")
+data class Narrative(
+
+    // The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.
+    @SerialName("status")
+    override val status: NarrativeStatus,
+    // Limited xhtml content.
+    @SerialName("div")
+    override val div: String,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirNarrative {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Narrative"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Period.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Period.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirPeriod : FhirElement {
+
+    // Starting time with inclusive boundary.
+    val start: String?
+
+    // End time with inclusive boundary, if not ongoing.
+    val end: String?
+}
+
+
+/**
+ * ClassName: Period
+ *
+ * SourceFileName: Period.kt
+ *
+ *
+ * A time period defined by a start and end date and optionally time.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Period">Period</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Period) on 2020-10-01
+ */
+@Serializable
+@SerialName("Period")
+data class Period(
+
+    // Starting time with inclusive boundary.
+    @SerialName("start")
+    override val start: String? = null,
+    // End time with inclusive boundary, if not ongoing.
+    @SerialName("end")
+    override val end: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirPeriod {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Period"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Quantity.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Quantity.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.QuantityComparator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirQuantity : FhirElement {
+
+    // Numerical value (with implicit precision).
+    val value: String?
+
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    val comparator: QuantityComparator?
+
+    // Unit representation.
+    val unit: String?
+
+    // System that defines coded unit form.
+    val system: String?
+
+    // Coded form of the unit.
+    val code: String?
+}
+
+
+/**
+ * ClassName: Quantity
+ *
+ * SourceFileName: Quantity.kt
+ *
+ *
+ * A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Quantity">Quantity</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Quantity) on 2020-10-01
+ */
+@Serializable
+@SerialName("Quantity")
+data class Quantity(
+
+    // Numerical value (with implicit precision).
+    @SerialName("value")
+    override val value: String? = null,
+    // How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is "<" , then the real value is < stated value.
+    @SerialName("comparator")
+    override val comparator: QuantityComparator? = null,
+    // Unit representation.
+    @SerialName("unit")
+    override val unit: String? = null,
+    // System that defines coded unit form.
+    @SerialName("system")
+    override val system: String? = null,
+    // Coded form of the unit.
+    @SerialName("code")
+    override val code: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirQuantity {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Quantity"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Range.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Range.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirRange : FhirElement {
+
+    // Low limit.
+    val low: Quantity?
+
+    // High limit.
+    val high: Quantity?
+}
+
+
+/**
+ * ClassName: Range
+ *
+ * SourceFileName: Range.kt
+ *
+ *
+ * A set of ordered Quantities defined by a low and high limit.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Range">Range</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Range) on 2020-10-01
+ */
+@Serializable
+@SerialName("Range")
+data class Range(
+
+    // Low limit.
+    @SerialName("low")
+    override val low: Quantity? = null,
+    // High limit.
+    @SerialName("high")
+    override val high: Quantity? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirRange {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Range"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Ratio.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Ratio.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirRatio : FhirElement {
+
+    // Numerator value.
+    val numerator: Quantity?
+
+    // Denominator value.
+    val denominator: Quantity?
+}
+
+
+/**
+ * ClassName: Ratio
+ *
+ * SourceFileName: Ratio.kt
+ *
+ *
+ * A relationship of two Quantity values - expressed as a numerator and a denominator.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Ratio">Ratio</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Ratio) on 2020-10-01
+ */
+@Serializable
+@SerialName("Ratio")
+data class Ratio(
+
+    // Numerator value.
+    @SerialName("numerator")
+    override val numerator: Quantity? = null,
+    // Denominator value.
+    @SerialName("denominator")
+    override val denominator: Quantity? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirRatio {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Ratio"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Reference.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Reference.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirReference : FhirElement {
+
+    // Literal reference, Relative, internal or absolute URL.
+    val reference: String?
+
+    // Logical reference, when literal reference is not known.
+    val identifier: Identifier?
+
+    // Text alternative for the resource.
+    val display: String?
+}
+
+
+/**
+ * ClassName: Reference
+ *
+ * SourceFileName: Reference.kt
+ *
+ *
+ * A reference from one resource to another
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Reference">Reference</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Reference) on 2020-10-01
+ */
+@Serializable
+@SerialName("Reference")
+data class Reference(
+
+    // Literal reference, Relative, internal or absolute URL.
+    @SerialName("reference")
+    override val reference: String? = null,
+    // Logical reference, when literal reference is not known.
+    @SerialName("identifier")
+    override val identifier: Identifier? = null,
+    // Text alternative for the resource.
+    @SerialName("display")
+    override val display: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirReference {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Reference"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Resource.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Resource.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirResource : FhirStu3 {
+
+    // Logical id of this artifact.
+    val id: String?
+
+    // Metadata about the resource.
+    val meta: Meta?
+
+    // A set of rules under which this content was created.
+    val implicitRules: String?
+
+    // Language of the resource content.
+    val language: String?
+}
+
+
+/**
+ * ClassName: Resource
+ *
+ * SourceFileName: Resource.kt
+ *
+ *
+ * This is the base resource type for everything.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Resource">Resource</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Resource) on 2020-10-01
+ */
+@Serializable
+@SerialName("Resource")
+data class Resource(
+
+    // Logical id of this artifact.
+    @SerialName("id")
+    override val id: String? = null,
+    // Metadata about the resource.
+    @SerialName("meta")
+    override val meta: Meta? = null,
+    // A set of rules under which this content was created.
+    @SerialName("implicitRules")
+    override val implicitRules: String? = null,
+    // Language of the resource content.
+    @SerialName("language")
+    override val language: String? = null
+) : FhirResource {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Resource"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/SampledData.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/SampledData.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirSampledData : FhirElement {
+
+    // Zero value and units.
+    val origin: Quantity
+
+    // Number of milliseconds between samples.
+    val period: String
+
+    // Multiply data by this before adding to origin.
+    val factor: String?
+
+    // Lower limit of detection.
+    val lowerLimit: String?
+
+    // Upper limit of detection.
+    val upperLimit: String?
+
+    // Number of sample points at each time point.
+    val dimensions: String
+
+    // Decimal values with spaces, or "E" | "U" | "L".
+    val data: String
+}
+
+
+/**
+ * ClassName: SampledData
+ *
+ * SourceFileName: SampledData.kt
+ *
+ *
+ * A series of measurements taken by a device, with upper and lower limits. There may be more than one dimension in the data.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/SampledData">SampledData</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/SampledData) on 2020-10-01
+ */
+@Serializable
+@SerialName("SampledData")
+data class SampledData(
+
+    // Zero value and units.
+    @SerialName("origin")
+    override val origin: Quantity,
+    // Number of milliseconds between samples.
+    @SerialName("period")
+    override val period: String,
+    // Multiply data by this before adding to origin.
+    @SerialName("factor")
+    override val factor: String? = null,
+    // Lower limit of detection.
+    @SerialName("lowerLimit")
+    override val lowerLimit: String? = null,
+    // Upper limit of detection.
+    @SerialName("upperLimit")
+    override val upperLimit: String? = null,
+    // Number of sample points at each time point.
+    @SerialName("dimensions")
+    override val dimensions: String,
+    // Decimal values with spaces, or "E" | "U" | "L".
+    @SerialName("data")
+    override val data: String,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirSampledData {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "SampledData"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Signature.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Signature.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirSignature : FhirElement {
+
+    // Indication of the reason the entity signed the object(s).
+    val type: List<Coding>
+
+    // When the signature was created.
+    val `when`: String
+
+    // Who signed.
+    val whoUri: String?
+
+    // Who signed.
+    val whoReference: Reference?
+
+    // The party represented.
+    val onBehalfOfUri: String?
+
+    // The party represented.
+    val onBehalfOfReference: Reference?
+
+    // The technical format of the signature.
+    val contentType: String?
+
+    // The actual signature content (XML DigSig. JWT, picture, etc.).
+    val blob: String?
+}
+
+
+/**
+ * ClassName: Signature
+ *
+ * SourceFileName: Signature.kt
+ *
+ *
+ * A digital signature along with supporting context. The signature may be electronic/cryptographic in nature, or a graphical image representing a hand-written signature, or a signature process. Different signature approaches have different utilities.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Signature">Signature</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Signature) on 2020-10-01
+ */
+@Serializable
+@SerialName("Signature")
+data class Signature(
+
+    // Indication of the reason the entity signed the object(s).
+    @SerialName("type")
+    override val type: List<Coding>,
+    // When the signature was created.
+    @SerialName("when")
+    override val `when`: String,
+    // Who signed.
+    @SerialName("whoUri")
+    override val whoUri: String? = null,
+    // Who signed.
+    @SerialName("whoReference")
+    override val whoReference: Reference? = null,
+    // The party represented.
+    @SerialName("onBehalfOfUri")
+    override val onBehalfOfUri: String? = null,
+    // The party represented.
+    @SerialName("onBehalfOfReference")
+    override val onBehalfOfReference: Reference? = null,
+    // The technical format of the signature.
+    @SerialName("contentType")
+    override val contentType: String? = null,
+    // The actual signature content (XML DigSig. JWT, picture, etc.).
+    @SerialName("blob")
+    override val blob: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirSignature {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Signature"
+    }
+}
+

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Timing.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/fhir/stu3/model/Timing.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2020. D4L data4life gGmbH / All rights reserved.
+ *
+ * D4L owns all legal rights, title and interest in and to the Software Development Kit ("SDK"),
+ * including any intellectual property rights that subsist in the SDK.
+ *
+ * The SDK and its documentation may be accessed and used for viewing/review purposes only.
+ * Any usage of the SDK for other purposes, including usage for the development of
+ * applications/third-party applications shall require the conclusion of a license agreement
+ * between you and D4L.
+ *
+ * If you are interested in licensing the SDK for your own applications/third-party
+ * applications and/or if you’d like to contribute to the development of the SDK, please
+ * contact D4L by email to help@data4life.care.
+ */
+
+package care.data4life.fhir.stu3.model
+
+import care.data4life.fhir.stu3.codesystem.DaysOfWeek
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmStatic
+
+
+interface FhirTiming : FhirElement {
+
+    // When the event occurs.
+    val event: List<String>?
+
+    // When the event is to occur.
+    val repeat: TimingRepeat?
+
+    // BID | TID | QID | AM | PM | QD | QOD | Q4H | Q6H +.
+    val code: CodeableConcept?
+}
+
+
+/**
+ * ClassName: Timing
+ *
+ * SourceFileName: Timing.kt
+ *
+ *
+ * Specifies an event that may occur multiple times. Timing schedules are used to record when things are planned, expected or requested to occur. The most common usage is in dosage instructions for medications. They are also used when planning care of various kinds, and may be used for reporting the schedule to which past regular activities were carried out.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Timing">Timing</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Timing) on 2020-10-01
+ */
+@Serializable
+@SerialName("Timing")
+data class Timing(
+
+    // When the event occurs.
+    @SerialName("event")
+    override val event: List<String>? = null,
+    // When the event is to occur.
+    @SerialName("repeat")
+    override val repeat: TimingRepeat? = null,
+    // BID | TID | QID | AM | PM | QD | QOD | Q4H | Q6H +.
+    @SerialName("code")
+    override val code: CodeableConcept? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirTiming {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "Timing"
+    }
+}
+
+
+interface FhirTimingRepeat : FhirElement {
+
+    // Length/Range of lengths, or (Start and/or end) limits.
+    val boundsDuration: Duration?
+
+    // Length/Range of lengths, or (Start and/or end) limits.
+    val boundsRange: Range?
+
+    // Length/Range of lengths, or (Start and/or end) limits.
+    val boundsPeriod: Period?
+
+    // Number of times to repeat.
+    val count: String?
+
+    // Maximum number of times to repeat.
+    val countMax: String?
+
+    // How long when it happens.
+    val duration: String?
+
+    // How long when it happens (Max).
+    val durationMax: String?
+
+    // s | min | h | d | wk | mo | a - unit of time (UCUM).
+    val durationUnit: String?
+
+    // Event occurs frequency times per period.
+    val frequency: String?
+
+    // Event occurs up to frequencyMax times per period.
+    val frequencyMax: String?
+
+    // Event occurs frequency times per period.
+    val period: String?
+
+    // Upper limit of period (3-4 hours).
+    val periodMax: String?
+
+    // s | min | h | d | wk | mo | a - unit of time (UCUM).
+    val periodUnit: String?
+
+    // If one or more days of week is provided, then the action happens only on the specified day(s).
+    val dayOfWeek: List<DaysOfWeek>?
+
+    // Time of day for action.
+    val timeOfDay: List<String>?
+
+    // Regular life events the event is tied to.
+    val `when`: List<String>?
+
+    // Minutes from event (before or after).
+    val offset: String?
+}
+
+
+/**
+ * ClassName: TimingRepeat
+ *
+ * SourceFileName: Timing.kt
+ *
+ *
+ * A set of rules that describe when the event is scheduled.
+ *
+ * @see <a href="http://hl7.org/fhir/StructureDefinition/Timing">TimingRepeat</a>
+ *
+ * Generated from FHIR 3.0.1.11917 (http://hl7.org/fhir/StructureDefinition/Timing) on 2020-10-01
+ */
+@Serializable
+@SerialName("TimingRepeat")
+data class TimingRepeat(
+
+    // Length/Range of lengths, or (Start and/or end) limits.
+    @SerialName("boundsDuration")
+    override val boundsDuration: Duration? = null,
+    // Length/Range of lengths, or (Start and/or end) limits.
+    @SerialName("boundsRange")
+    override val boundsRange: Range? = null,
+    // Length/Range of lengths, or (Start and/or end) limits.
+    @SerialName("boundsPeriod")
+    override val boundsPeriod: Period? = null,
+    // Number of times to repeat.
+    @SerialName("count")
+    override val count: String? = null,
+    // Maximum number of times to repeat.
+    @SerialName("countMax")
+    override val countMax: String? = null,
+    // How long when it happens.
+    @SerialName("duration")
+    override val duration: String? = null,
+    // How long when it happens (Max).
+    @SerialName("durationMax")
+    override val durationMax: String? = null,
+    // s | min | h | d | wk | mo | a - unit of time (UCUM).
+    @SerialName("durationUnit")
+    override val durationUnit: String? = null,
+    // Event occurs frequency times per period.
+    @SerialName("frequency")
+    override val frequency: String? = null,
+    // Event occurs up to frequencyMax times per period.
+    @SerialName("frequencyMax")
+    override val frequencyMax: String? = null,
+    // Event occurs frequency times per period.
+    @SerialName("period")
+    override val period: String? = null,
+    // Upper limit of period (3-4 hours).
+    @SerialName("periodMax")
+    override val periodMax: String? = null,
+    // s | min | h | d | wk | mo | a - unit of time (UCUM).
+    @SerialName("periodUnit")
+    override val periodUnit: String? = null,
+    // If one or more days of week is provided, then the action happens only on the specified day(s).
+    @SerialName("dayOfWeek")
+    override val dayOfWeek: List<DaysOfWeek>? = null,
+    // Time of day for action.
+    @SerialName("timeOfDay")
+    override val timeOfDay: List<String>? = null,
+    // Regular life events the event is tied to.
+    @SerialName("when")
+    override val `when`: List<String>? = null,
+    // Minutes from event (before or after).
+    @SerialName("offset")
+    override val offset: String? = null,
+
+
+    // # Element
+    // xml:id (or equivalent in JSON).
+    @SerialName("id")
+    override val id: String? = null,
+    // Additional Content defined by implementations.
+    @SerialName("extension")
+    override val extension: List<Extension>? = null
+) : FhirTimingRepeat {
+
+    override val resourceType: kotlin.String
+        get() = resourceType()
+
+
+    companion object {
+        @JvmStatic
+        fun resourceType(): kotlin.String = "TimingRepeat"
+    }
+}
+


### PR DESCRIPTION
### :tophat: What is the goal?
Add generated FHIR STU3 models for for `base`, `complex`, `special`

### :unicorn: How is it being implemented?
Enable `movefiles` in Fastlane Action `fhir_kotlin.rb` for `base`, `complex`, `special`

**!** You need to format the generated code as the generation is not producing clean code

**!** IntelliJ -> `Code` -> `Reformat Code` -> check  `Include subdirectories`, `Optimise imports`  `Scope: Module fhir` -> hit `run` -> wait

### :thinking: DOD Checklist

- [x] Code style and naming conventions met
- [ ] Test written and passing
- [x] Continuous Integration build passing
- [ ] Cross platform testing done on Android and iOS
- [ ] Code peer-reviewed
- [ ] Documentation updated
- [x] Changelog updated
- [x] Acceptance criteria met

