### PR TITLE
Change XsDateTime implementation to common

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ toc::[]
 === Changed
 
 * Change FHIR STU3 config to allow multiple FHIR versions
+* Change XsDateTime implementation to common for reuse in different FHIR versions
 
 === Removed
 

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/CodeSystem.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/CodeSystem.kt
@@ -16,7 +16,11 @@
 
 package care.data4life.hl7.fhir.stu3.model
 
-import care.data4life.hl7.fhir.stu3.codesystem.*
+import care.data4life.hl7.fhir.stu3.codesystem.CodeSystemContentMode
+import care.data4life.hl7.fhir.stu3.codesystem.CodeSystemHierarchyMeaning
+import care.data4life.hl7.fhir.stu3.codesystem.FilterOperator
+import care.data4life.hl7.fhir.stu3.codesystem.PropertyType
+import care.data4life.hl7.fhir.stu3.codesystem.PublicationStatus
 import care.data4life.hl7.fhir.stu3.primitive.Bool
 import care.data4life.hl7.fhir.stu3.primitive.DateTime
 import care.data4life.hl7.fhir.stu3.primitive.Integer

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Extension.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Extension.kt
@@ -16,7 +16,15 @@
 
 package care.data4life.hl7.fhir.stu3.model
 
-import care.data4life.hl7.fhir.stu3.primitive.*
+import care.data4life.hl7.fhir.stu3.primitive.Bool
+import care.data4life.hl7.fhir.stu3.primitive.Date
+import care.data4life.hl7.fhir.stu3.primitive.DateTime
+import care.data4life.hl7.fhir.stu3.primitive.Decimal
+import care.data4life.hl7.fhir.stu3.primitive.Instant
+import care.data4life.hl7.fhir.stu3.primitive.Integer
+import care.data4life.hl7.fhir.stu3.primitive.PositiveInteger
+import care.data4life.hl7.fhir.stu3.primitive.Time
+import care.data4life.hl7.fhir.stu3.primitive.UnsignedInteger
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmStatic

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Questionnaire.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Questionnaire.kt
@@ -19,7 +19,12 @@ package care.data4life.hl7.fhir.stu3.model
 import care.data4life.hl7.fhir.stu3.codesystem.PublicationStatus
 import care.data4life.hl7.fhir.stu3.codesystem.QuestionnaireItemType
 import care.data4life.hl7.fhir.stu3.codesystem.ResourceType
-import care.data4life.hl7.fhir.stu3.primitive.*
+import care.data4life.hl7.fhir.stu3.primitive.Bool
+import care.data4life.hl7.fhir.stu3.primitive.Date
+import care.data4life.hl7.fhir.stu3.primitive.DateTime
+import care.data4life.hl7.fhir.stu3.primitive.Decimal
+import care.data4life.hl7.fhir.stu3.primitive.Integer
+import care.data4life.hl7.fhir.stu3.primitive.Time
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmStatic

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/QuestionnaireResponse.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/QuestionnaireResponse.kt
@@ -17,7 +17,12 @@
 package care.data4life.hl7.fhir.stu3.model
 
 import care.data4life.hl7.fhir.stu3.codesystem.QuestionnaireResponseStatus
-import care.data4life.hl7.fhir.stu3.primitive.*
+import care.data4life.hl7.fhir.stu3.primitive.Bool
+import care.data4life.hl7.fhir.stu3.primitive.Date
+import care.data4life.hl7.fhir.stu3.primitive.DateTime
+import care.data4life.hl7.fhir.stu3.primitive.Decimal
+import care.data4life.hl7.fhir.stu3.primitive.Integer
+import care.data4life.hl7.fhir.stu3.primitive.Time
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmStatic

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Timing.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/Timing.kt
@@ -17,7 +17,11 @@
 package care.data4life.hl7.fhir.stu3.model
 
 import care.data4life.hl7.fhir.stu3.codesystem.DaysOfWeek
-import care.data4life.hl7.fhir.stu3.primitive.*
+import care.data4life.hl7.fhir.stu3.primitive.DateTime
+import care.data4life.hl7.fhir.stu3.primitive.Decimal
+import care.data4life.hl7.fhir.stu3.primitive.Integer
+import care.data4life.hl7.fhir.stu3.primitive.Time
+import care.data4life.hl7.fhir.stu3.primitive.UnsignedInteger
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmStatic

--- a/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/ValueSet.kt
+++ b/fhir/src-gen/commonMain/kotlin/care/data4life/hl7/fhir/stu3/model/ValueSet.kt
@@ -18,7 +18,11 @@ package care.data4life.hl7.fhir.stu3.model
 
 import care.data4life.hl7.fhir.stu3.codesystem.FilterOperator
 import care.data4life.hl7.fhir.stu3.codesystem.PublicationStatus
-import care.data4life.hl7.fhir.stu3.primitive.*
+import care.data4life.hl7.fhir.stu3.primitive.Bool
+import care.data4life.hl7.fhir.stu3.primitive.Date
+import care.data4life.hl7.fhir.stu3.primitive.DateTime
+import care.data4life.hl7.fhir.stu3.primitive.Decimal
+import care.data4life.hl7.fhir.stu3.primitive.Integer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmStatic

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDate.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDate.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import care.data4life.hl7.fhir.stu3.json.XsDateParser
 import kotlinx.datetime.LocalDate

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTime.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
 import kotlinx.serialization.Serializable

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTime.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import care.data4life.hl7.fhir.stu3.json.XsTimeParser
 import kotlinx.serialization.Serializable

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeZone.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeZone.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import kotlinx.serialization.Serializable
 

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateParser.kt
@@ -16,8 +16,8 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
+import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.parser.json.StringParser
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
 
 /**
  * XsDateParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeFormatter.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeFormatter.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 
 object XsDateTimeFormatter {
 

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeParser.kt
@@ -16,8 +16,8 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
 import care.data4life.hl7.fhir.parser.json.StringParser
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
 
 object XsDateTimeParser : StringParser<XsDateTime> {
 

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeParser.kt
@@ -16,8 +16,8 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
+import care.data4life.hl7.fhir.common.datetime.XsTime
 import care.data4life.hl7.fhir.parser.json.StringParser
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
 
 /**
  * XsTimeParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeZoneParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeZoneParser.kt
@@ -16,8 +16,8 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.parser.json.StringParser
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
 
 /**
  * XsTimeZoneParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Date.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Date.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.stu3.json.XsDateParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTime.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
 import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Instant.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Instant.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
 import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Time.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Time.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
 import care.data4life.hl7.fhir.stu3.json.XsTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTimeTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTimeTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeZoneTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/XsTimeZoneTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.datetime
+package care.data4life.hl7.fhir.common.datetime
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/DateJsonParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/DateJsonParserTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirStu3
 import care.data4life.hl7.fhir.stu3.primitive.Date

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/DateTimeJsonParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/DateTimeJsonParserTest.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirStu3
 import care.data4life.hl7.fhir.stu3.primitive.DateTime

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/InstantJsonParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/InstantJsonParserTest.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirStu3
 import care.data4life.hl7.fhir.stu3.primitive.Instant

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/TimeJsonParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/TimeJsonParserTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirStu3
 import care.data4life.hl7.fhir.stu3.primitive.Time

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateParserTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsDateTimeParserTest.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeParserTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeZoneParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/json/XsTimeZoneParserTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.json
 
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.stu3.model.Extension
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTimeTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTimeTest.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.stu3.model.Extension
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/InstantTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/InstantTest.kt
@@ -16,10 +16,10 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.datetime.XsTimeZone
+import care.data4life.hl7.fhir.common.datetime.XsDate
+import care.data4life.hl7.fhir.common.datetime.XsDateTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.stu3.model.Extension
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/TimeTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/stu3/primitive/TimeTest.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.stu3.primitive
 
-import care.data4life.hl7.fhir.stu3.datetime.XsTime
+import care.data4life.hl7.fhir.common.datetime.XsTime
 import care.data4life.hl7.fhir.stu3.model.Extension
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
### :tophat: What is the goal?

Prepare reuse of Date implementation

### :unicorn: How is it being implemented?

Change XsDateTime implementation to common for reuse in different FHIR versions

### :thinking: DOD Checklist

- [ ] Code style and naming conventions met
- [ ] Test written and passing
- [ ] Continuous Integration build passing
- [ ] Cross platform testing done on Android and iOS
- [ ] Code peer-reviewed
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Acceptance criteria met
