### PR TITLE
Change datetime parser to common

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,7 +25,7 @@ toc::[]
 === Changed
 
 * Change FHIR STU3 config to allow multiple FHIR versions
-* Change XsDateTime implementation to common for reuse in different FHIR versions
+* Change XsDateTime implementation and parser to common for reuse in different FHIR versions
 
 === Removed
 

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDate.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDate.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.common.datetime
 
-import care.data4life.hl7.fhir.stu3.json.XsDateParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsDateParser
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsDateTime.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.common.datetime
 
-import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsDateTimeParser
 import kotlinx.serialization.Serializable
 
 /**

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/XsTime.kt
@@ -16,7 +16,7 @@
 
 package care.data4life.hl7.fhir.common.datetime
 
-import care.data4life.hl7.fhir.stu3.json.XsTimeParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsTimeParser
 import kotlinx.serialization.Serializable
 
 /**

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/FormatHelper.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/FormatHelper.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 /**
  * Returns a String representation prepended with zeros until given [length]

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateParser.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.parser.json.StringParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeFormatter.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeFormatter.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.common.datetime.XsDateTime

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeParser.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsDateTime
 import care.data4life.hl7.fhir.parser.json.StringParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeParser.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsTime
 import care.data4life.hl7.fhir.parser.json.StringParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeZoneParser.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeZoneParser.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import care.data4life.hl7.fhir.parser.json.StringParser

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Date.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Date.kt
@@ -17,7 +17,7 @@
 package care.data4life.hl7.fhir.stu3.primitive
 
 import care.data4life.hl7.fhir.common.datetime.XsDate
-import care.data4life.hl7.fhir.stu3.json.XsDateParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsDateParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement
 import kotlinx.serialization.KSerializer

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTime.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/DateTime.kt
@@ -17,7 +17,7 @@
 package care.data4life.hl7.fhir.stu3.primitive
 
 import care.data4life.hl7.fhir.common.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsDateTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement
 import kotlinx.serialization.*

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Instant.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Instant.kt
@@ -17,7 +17,7 @@
 package care.data4life.hl7.fhir.stu3.primitive
 
 import care.data4life.hl7.fhir.common.datetime.XsDateTime
-import care.data4life.hl7.fhir.stu3.json.XsDateTimeParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsDateTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement
 import kotlinx.serialization.KSerializer

--- a/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Time.kt
+++ b/fhir/src/commonMain/kotlin/care/data4life/hl7/fhir/stu3/primitive/Time.kt
@@ -17,7 +17,7 @@
 package care.data4life.hl7.fhir.stu3.primitive
 
 import care.data4life.hl7.fhir.common.datetime.XsTime
-import care.data4life.hl7.fhir.stu3.json.XsTimeParser
+import care.data4life.hl7.fhir.common.datetime.parser.XsTimeParser
 import care.data4life.hl7.fhir.stu3.model.Extension
 import care.data4life.hl7.fhir.stu3.model.FhirElement
 import kotlinx.serialization.KSerializer

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateParserTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsDate
 import kotlin.test.Test

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsDateTimeParserTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsDate
 import care.data4life.hl7.fhir.common.datetime.XsDateTime

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeParserTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsTime
 import kotlin.test.Test

--- a/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeZoneParserTest.kt
+++ b/fhir/src/jvmTest/kotlin/care/data4life/hl7/fhir/common/datetime/parser/XsTimeZoneParserTest.kt
@@ -14,7 +14,7 @@
  * contact D4L by email to help@data4life.care.
  */
 
-package care.data4life.hl7.fhir.stu3.json
+package care.data4life.hl7.fhir.common.datetime.parser
 
 import care.data4life.hl7.fhir.common.datetime.XsTimeZone
 import kotlin.test.Test


### PR DESCRIPTION
### :tophat: What is the goal?

Prepare reuse of Date implementation

### :unicorn: How is it being implemented?

Change XsDateTime parser to common for reuse in different FHIR versions

### :thinking: DOD Checklist

- [ ] Code style and naming conventions met
- [ ] Test written and passing
- [ ] Continuous Integration build passing
- [ ] Cross platform testing done on Android and iOS
- [ ] Code peer-reviewed
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Acceptance criteria met
