### PR TITLE
Change to cloud runner

### DIFF
--- a/.github/workflows/d4l-ci-pull-request-validation.yml
+++ b/.github/workflows/d4l-ci-pull-request-validation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pull-request-validation:
 
-    runs-on: [self-hosted, macos]
+    runs-on: macos-10.15
 
     concurrency:
       group: ${{ github.head_ref }}


### PR DESCRIPTION
### :tophat: What is the goal?

GitHub Actions should run on public runners

### :unicorn: How is it being implemented?

Change runner from `self-hosted` to `macos-10.15`

### :thinking: DOD Checklist

- [ ] Code style and naming conventions met
- [ ] Test written and passing
- [ ] Continuous Integration build passing
- [ ] Cross platform testing done on Android and iOS
- [ ] Code peer-reviewed
- [ ] Documentation updated
- [ ] Changelog updated
- [x] Acceptance criteria met
